### PR TITLE
don't error on zero feerate

### DIFF
--- a/src/rpc/fees.cpp
+++ b/src/rpc/fees.cpp
@@ -82,15 +82,15 @@ static RPCHelpMan estimatesmartfee()
             UniValue errors(UniValue::VARR);
             FeeCalculation feeCalc;
             CFeeRate feeRate{fee_estimator.estimateSmartFee(conf_target, &feeCalc, conservative)};
-            if (feeRate != CFeeRate(0)) {
+            // if (feeRate != CFeeRate(0)) {
                 CFeeRate min_mempool_feerate{mempool.GetMinFee()};
                 CFeeRate min_relay_feerate{mempool.m_min_relay_feerate};
                 feeRate = std::max({feeRate, min_mempool_feerate, min_relay_feerate});
                 result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
-            } else {
-                errors.push_back("Insufficient data or no feerate found");
-                result.pushKV("errors", errors);
-            }
+            // } else {
+            //     errors.push_back("Insufficient data or no feerate found");
+            //     result.pushKV("errors", errors);
+            // }
             result.pushKV("blocks", feeCalc.returnedTarget);
             return result;
         },


### PR DESCRIPTION
bitcoind returns an error when there's a fee estimate of zero sats. This may also be a problem upstream in core, but it's especially annoying on Mutinynet, where there are rarely recent transactions.

This allows bitcoind to simply return 0 when the estimate is 0.